### PR TITLE
Revert "[fix]大きいディスプレイで幅600px以下にした時の表示を修正"

### DIFF
--- a/dist/css/style.css
+++ b/dist/css/style.css
@@ -296,6 +296,13 @@ h1 {
     max-height: 100%;
   }
 
+  #bg-photo {
+    height: auto;
+    min-height: 125px;
+    background-size: 200% auto;
+    background-position: top left;
+  }
+
   h1 {
     margin: auto 20px auto 20px;
     text-align: left;


### PR DESCRIPTION
This reverts commit 9caa83a4c9b4424a8a00fbc891c4c3a29759ffc7.

実機で確認したら背景画像のサイズとポジションが意図しない表示になっていたため打消し